### PR TITLE
Support multiple GUID formats when serializing

### DIFF
--- a/fastJSON/JSON.cs
+++ b/fastJSON/JSON.cs
@@ -29,6 +29,19 @@ namespace fastJSON
         /// Use the fast GUID format (default = True)
         /// </summary>
         public bool UseFastGuid = true;
+
+        /// <summary>
+        /// The format to use when serializing GUID values.
+        /// Lower case will use lower case 'a'...'f', upper case will use upper case letters 'A'...'F'
+        ///
+        /// N: 00000000000000000000000000000000
+	    /// D: 00000000-0000-0000-0000-000000000000
+	    /// B: {00000000-0000-0000-0000-000000000000}
+	    /// P: (00000000-0000-0000-0000-000000000000)
+	    /// X: {0x00000000,0x0000,0x0000,{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00}}
+        /// </summary>
+        public string GuidStringFormat = null;       // use fastJSON format
+
         /// <summary>
         /// Serialize null values to the output (default = True)
         /// </summary>

--- a/fastJSON/JsonSerializer.cs
+++ b/fastJSON/JsonSerializer.cs
@@ -254,10 +254,37 @@ namespace fastJSON
 
         private void WriteGuid(Guid g)
         {
-            if (_params.UseFastGuid == false)
-                WriteStringFast(g.ToString());
-            else
+            if (_params.UseFastGuid)
+            {
                 WriteBytes(g.ToByteArray());
+            }
+            else
+            {
+                switch (_params.GuidStringFormat)
+                {
+                    case "N":
+                    case "D":
+                    case "B":
+                    case "P":
+                        WriteStringFast(g.ToString(_params.GuidStringFormat).ToUpperInvariant());
+                        break;
+                    case "X":
+                        WriteStringFast(g.ToString("X").ToUpperInvariant().Replace('X', 'x'));
+                        break;
+                    case "n":
+                    case "d":
+                    case "b":
+                    case "p":
+                        WriteStringFast(g.ToString(_params.GuidStringFormat.ToUpperInvariant()).ToLowerInvariant());
+                        break;
+                    case "x":
+                        WriteStringFast(g.ToString("X").ToLowerInvariant());
+                        break;
+                    default:
+                WriteStringFast(g.ToString());
+                        break;
+                }
+            }
         }
 
         private void WriteBytes(byte[] bytes)


### PR DESCRIPTION
* IBEX-6275
* added GuidStringFormat property to JSONParameters
* changed WriteGuid() to support multiple formats